### PR TITLE
Explicitly set sudo to false, rather than sudo w/the ansible SSH user.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,8 +32,7 @@
 # get the agent forwarding.
 - name: clone repo to application directory
   git: dest={{ git_application_deploy_to }} repo={{ git_application_repo }} version={{ git_application_version }} accept_hostkey=yes
-  sudo: yes
-  sudo_user: "{{ ansible_ssh_user }}"
+  sudo: no
   when: git_application_pull_from_git == True
 
 - name: remove write access from 'group' and 'other'


### PR DESCRIPTION
This stops issues with SSH forwarding (no idea why this behaviour has changed, but I cannot deploy anything without this currently - both Ansible 1/2).

End result is the same, just stops Ansible wrapping things with sudo unnecessarily.

EDIT: turns out this was just because Ansible decided to break `1.9.4`'s behaviour by always attaching sudo when set, but `2.1.0` and `1.8.4` both magically remove the sudo when sudo user is the same as the SSH user (horrible). This PR makes the role compatible with (possible) all Ansible versions.