### PR TITLE
Add default var for force=yes and use it when cloning repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,4 @@ git_application_user: myuser
 git_application_group: myusergroup
 
 git_application_pull_from_git: yes
+git_application_force: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,12 @@
 # We need to run the git clone as the ansible ssh user. Otherwise we won't
 # get the agent forwarding.
 - name: clone repo to application directory
-  git: dest={{ git_application_deploy_to }} repo={{ git_application_repo }} version={{ git_application_version }} accept_hostkey=yes
+  git: >
+    dest={{ git_application_deploy_to }}
+    repo={{ git_application_repo }}
+    version={{ git_application_version }}
+    accept_hostkey=yes
+    force={{ git_application_force }}
   sudo: no
   when: git_application_pull_from_git == True
 


### PR DESCRIPTION
@EDITD/hackers This adds and uses a `git_application_force` var, which defaults to `yes`.

We recently had deploy failures because of using ansible 2, which according to [the docs for git module](http://docs.ansible.com/ansible/git_module.html) switched from having `force=yes` as the default to `force=no`.